### PR TITLE
Add optional grouping of features by path in tree view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Back to [Readme](README.md).
 
+## [3.11.0] - Work In Progress
+
+### Added
+
+* Optional grouping of features by their path in tree view
+
+
 ## [3.10.0] - 2025-01-06
 
 ### Added

--- a/core/src/main/java/com/trivago/cluecumber/core/CluecumberCore.java
+++ b/core/src/main/java/com/trivago/cluecumber/core/CluecumberCore.java
@@ -22,6 +22,7 @@ import com.trivago.cluecumber.engine.exceptions.CluecumberException;
 import com.trivago.cluecumber.engine.logging.CluecumberLogger;
 
 import java.util.LinkedHashMap;
+import java.util.Set;
 
 /**
  * The main Cluecumber core class that passes properties to the Cluecumber engine.
@@ -48,6 +49,9 @@ public class CluecumberCore {
         cluecumberEngine.setCustomStatusColorFailed(builder.customStatusColorFailed);
         cluecumberEngine.setCustomStatusColorPassed(builder.customStatusColorPassed);
         cluecumberEngine.setCustomStatusColorSkipped(builder.customStatusColorSkipped);
+        cluecumberEngine.setGroupFeaturesByPath(builder.groupFeaturesByPath);
+        cluecumberEngine.setRemovableBasePaths(builder.removableBasePaths);
+        cluecumberEngine.setDirectoryNameFormatter(builder.directoryNameFormatter);
         cluecumberEngine.setExpandSubSections(builder.expandSubSections);
         cluecumberEngine.setExpandAttachments(builder.expandAttachments);
         cluecumberEngine.setExpandBeforeAfterHooks(builder.expandBeforeAfterHooks);
@@ -86,6 +90,9 @@ public class CluecumberCore {
         private String customStatusColorFailed;
         private String customStatusColorPassed;
         private String customStatusColorSkipped;
+        private Set<String> removableBasePaths;
+        private String directoryNameFormatter;
+        private boolean groupFeaturesByPath;
         private boolean expandSubSections;
         private boolean expandAttachments;
         private boolean expandBeforeAfterHooks;
@@ -211,6 +218,39 @@ public class CluecumberCore {
          */
         public Builder setCustomStatusColorSkipped(final String customStatusColorSkipped) {
             this.customStatusColorSkipped = customStatusColorSkipped;
+            return this;
+        }
+
+        /**
+         * Whether to group features by path in the tree view.
+         *
+         * @param groupFeaturesByPath If true, the tree view will group features by their directory paths.
+         * @return The {@link Builder}.
+         */
+        public Builder setGroupFeaturesByPath(final boolean groupFeaturesByPath) {
+            this.groupFeaturesByPath = groupFeaturesByPath;
+            return this;
+        }
+
+        /**
+         * Set the base paths to be removed from feature file URIs before grouping.
+         *
+         * @param removableBasePaths A set of strings representing the base paths.
+         * @return The {@link Builder}.
+         */
+        public Builder setRemovableBasePaths(final Set<String> removableBasePaths) {
+            this.removableBasePaths = removableBasePaths;
+            return this;
+        }
+
+        /**
+         * Set the directory name formatter for customizing directory names.
+         *
+         * @param directoryNameFormatter The fully qualified class name of the formatter implementation.
+         * @return The {@link Builder}.
+         */
+        public Builder setDirectoryNameFormatter(final String directoryNameFormatter) {
+            this.directoryNameFormatter = directoryNameFormatter;
             return this;
         }
 

--- a/engine/src/main/java/com/trivago/cluecumber/engine/CluecumberEngine.java
+++ b/engine/src/main/java/com/trivago/cluecumber/engine/CluecumberEngine.java
@@ -36,6 +36,7 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Set;
 
 import static com.trivago.cluecumber.engine.logging.CluecumberLogger.CluecumberLogLevel.COMPACT;
 import static com.trivago.cluecumber.engine.logging.CluecumberLogger.CluecumberLogLevel.DEFAULT;
@@ -195,6 +196,35 @@ public final class CluecumberEngine {
      */
     public void setCustomNavigationLinks(final LinkedHashMap<String, String> customNavigationLinks) {
         propertyManager.setCustomNavigationLinks(customNavigationLinks);
+    }
+
+    /**
+     * Set whether the report should group feature files by their path in the tree view.
+     *
+     * @param groupFeaturesByPath true to enable path-based tree view, false otherwise.
+     */
+    public void setGroupFeaturesByPath(final boolean groupFeaturesByPath) {
+        propertyManager.setGroupFeaturesByPath(groupFeaturesByPath);
+    }
+
+    /**
+     * Set the base paths to be removed from feature file URIs when used in grouping.
+     *
+     * @param removableBasePaths A set of strings representing the base paths.
+     * @throws WrongOrMissingPropertyException If the paths are invalid.
+     */
+    public void setRemovableBasePaths(final Set<String> removableBasePaths) throws WrongOrMissingPropertyException {
+        propertyManager.setRemovableBasePaths(removableBasePaths);
+    }
+
+    /**
+     * Set the directory name formatter.
+     *
+     * @param formatterClassName The fully qualified class name of the formatter implementation.
+     * @throws WrongOrMissingPropertyException Thrown if the class is invalid or missing.
+     */
+    public void setDirectoryNameFormatter(final String formatterClassName) throws WrongOrMissingPropertyException {
+        propertyManager.setDirectoryNameFormatter(formatterClassName);
     }
 
     /**

--- a/engine/src/main/java/com/trivago/cluecumber/engine/rendering/pages/pojos/pagecollections/TreeViewPageCollection.java
+++ b/engine/src/main/java/com/trivago/cluecumber/engine/rendering/pages/pojos/pagecollections/TreeViewPageCollection.java
@@ -17,34 +17,78 @@ package com.trivago.cluecumber.engine.rendering.pages.pojos.pagecollections;
 
 import com.trivago.cluecumber.engine.json.pojo.Element;
 import com.trivago.cluecumber.engine.rendering.pages.pojos.Feature;
+import com.trivago.cluecumber.engine.rendering.pages.renderering.PathFormatter;
 
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Page collection for the tree view page.
  */
 public class TreeViewPageCollection extends PageCollection {
-    private final Map<Feature, List<Element>> elements;
+    private final Set<Path> paths;
+    private final Map<Path, List<FeatureAndScenarios>> featuresByPath;
+    private final PathFormatter pathFormatter;
+
+    public static class FeatureAndScenarios {
+        private final Feature feature;
+        private final List<Element> scenarios;
+
+        public FeatureAndScenarios(Feature feature, List<Element> scenarios) {
+            this.feature = feature;
+            this.scenarios = scenarios;
+        }
+
+        public Feature getFeature() {
+            return feature;
+        }
+
+        public List<Element> getScenarios() {
+            return scenarios;
+        }
+    }
 
     /**
      * Constructor.
      *
-     * @param elements  The map of features and associated scenarios.
-     * @param pageTitle The title of the tree view page.
+     * @param paths          The paths of the features.
+     * @param featuresByPath The map of paths and associated features.
+     * @param pathFormatter  The formatter used to display paths.
+     * @param pageTitle      The title of the tree view page.
      */
-    public TreeViewPageCollection(final Map<Feature, List<Element>> elements, final String pageTitle) {
+    public TreeViewPageCollection(final Set<Path> paths, final Map<Path, List<FeatureAndScenarios>> featuresByPath, PathFormatter pathFormatter, final String pageTitle) {
         super(pageTitle);
-        this.elements = elements;
+        this.paths = paths;
+        this.featuresByPath = featuresByPath;
+        this.pathFormatter = pathFormatter;
     }
 
     /**
-     * Get the list of features and their scenarios.
+     * Get the paths of the features.
      *
-     * @return The map of features and associated scenarios.
+     * @return The paths of the features.
      */
-    public Map<Feature, List<Element>> getElements() {
-        return elements;
+    public Set<Path> getPaths() {
+        return paths;
+    }
+
+    /**
+     * Get the map of paths and their features.
+     *
+     * @return The map of paths and associated features.
+     */
+    public Map<Path, List<FeatureAndScenarios>> getFeaturesByPath() {
+        return featuresByPath;
+    }
+
+    /**
+     * Get the formatter used to turn the path into a displayable title.
+     * @return The formatter used for paths.
+     */
+    public PathFormatter getPathFormatter() {
+        return pathFormatter;
     }
 
     /**
@@ -53,7 +97,7 @@ public class TreeViewPageCollection extends PageCollection {
      * @return The count.
      */
     public int getNumberOfFeatures() {
-        return elements.size();
+        return featuresByPath.values().stream().mapToInt(List::size).sum();
     }
 
     /**
@@ -62,7 +106,7 @@ public class TreeViewPageCollection extends PageCollection {
      * @return The count.
      */
     public int getNumberOfScenarios() {
-        return elements.values().stream().mapToInt(List::size).sum();
+        return featuresByPath.values().stream().flatMap(List::stream).map(FeatureAndScenarios::getScenarios).mapToInt(List::size).sum();
     }
 }
 

--- a/engine/src/main/java/com/trivago/cluecumber/engine/rendering/pages/renderering/BasePaths.java
+++ b/engine/src/main/java/com/trivago/cluecumber/engine/rendering/pages/renderering/BasePaths.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2023 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.trivago.cluecumber.engine.rendering.pages.renderering;
+
+import com.trivago.cluecumber.engine.rendering.pages.pojos.Feature;
+
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * A set of potential base paths of feature file URIs.
+ *
+ * <p>These base paths can be stripped from the {@link Feature#getUri()} of {@link com.trivago.cluecumber.engine.rendering.pages.pojos.Feature} when presenting them hierarchically.
+ * <p>Example: {@code "/features/customer/registration.feature"} → {@code "/customer/registration.feature"}.
+ */
+public class BasePaths {
+    private final Set<Path> normalizedBasePaths;
+
+    /**
+     * Constructs a BasePaths object
+     *
+     * @param basePaths The collection of base paths
+     */
+    public BasePaths(Collection<Path> basePaths) {
+        Objects.requireNonNull(basePaths, "Base paths cannot be null");
+        this.normalizedBasePaths = basePaths.stream()
+                .map(BasePaths::normalizePath)
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Constructs a BasePaths object from a collection of strings, representing the paths.
+     *
+     * @param basePaths The collection of base paths
+     * @return the newly initialized instance
+     */
+    public static BasePaths fromStrings(Collection<String> basePaths) {
+        Set<Path> paths = Objects.requireNonNull(basePaths, "Base paths cannot be null").stream()
+                .map(Path::of)
+                .collect(Collectors.toSet());
+        return new BasePaths(paths);
+    }
+
+    /**
+     * Normalizes a path and treats it as "absolute" for comparison purposes.
+     *
+     * @param path The path to normalize.
+     * @return The normalized "absolute" path.
+     */
+    private static Path normalizePath(Path path) {
+        String pathString = path.toString();
+        if (!pathString.startsWith("/")) {
+            pathString = "/" + pathString;
+        }
+        return Path.of(pathString).normalize();
+    }
+
+    /**
+     * Gets the normalized base paths.
+     *
+     * @return An unmodifiable list of normalized base paths.
+     */
+    public Set<Path> getBasePaths() {
+        return Collections.unmodifiableSet(normalizedBasePaths);
+    }
+
+    /**
+     * Finds the longest matching base path for the given path and strips it.
+     *
+     * @param path The {@link Path} to process.
+     * @return The stripped path as a {@link Path}, or {@code "/"} if the resulting path is empty.
+     */
+    public Path stripBasePath(Path path) {
+        Path normalizedPath = normalizePath(Objects.requireNonNull(path, "Path cannot be null"));
+
+        Path bestMatch = null;
+        for (Path basePath : normalizedBasePaths) {
+            if (normalizedPath.startsWith(basePath) && (bestMatch == null || basePath.toString().length() > bestMatch.toString().length())) {
+                    bestMatch = basePath;
+            }
+        }
+
+        if (bestMatch != null) {
+            return normalizePath(bestMatch.relativize(normalizedPath));
+        }
+
+        return normalizedPath;
+    }
+}

--- a/engine/src/main/java/com/trivago/cluecumber/engine/rendering/pages/renderering/DirectoryNameFormatter.java
+++ b/engine/src/main/java/com/trivago/cluecumber/engine/rendering/pages/renderering/DirectoryNameFormatter.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2023 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.trivago.cluecumber.engine.rendering.pages.renderering;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * {@code DirectoryNameFormatter} defines the SPI for converting directory names
+ * to a display name.
+ *
+ * <p>Implementations of this interface are used to dynamically format directory names in the URI of feature files when presented in reports.
+ *
+ * <h2>Built-in Implementations</h2>
+ * <ul>
+ *     <li>{@link Standard}</li>
+ *     <li>{@link SnakeCase}</li>
+ *     <li>{@link CamelCase}</li>
+ *     <li>{@link KebabCase}</li>
+ * </ul>
+ */
+public interface DirectoryNameFormatter {
+
+    /**
+     * Converts a directory name into the display name based on the specific naming convention.
+     *
+     * @param name the original directory name, never {@code null}
+     * @return the formatted directory name
+     */
+    String toDisplayName(String name);
+
+    /**
+     * {@code Standard} formatter that uses the input name as-is without modification.
+     */
+    class Standard implements DirectoryNameFormatter {
+
+        @Override
+        public String toDisplayName(String name) {
+            return Objects.requireNonNull(name);
+        }
+    }
+
+    /**
+     * {@code Snake Case} formatter that converts snake_case names into Title Case.
+     *
+     * <p>Example: {@code "my_directory_name"} → {@code "My Directory Name"}.
+     *
+     * <p>Caveat: Minor words are capitalized as well, contrary to common Title Case standards.
+     * {@code "an_introduction_to_programming_with_java"} → {@code "An Introduction To Programming With Java"} instead of {@code "An Introduction to Programming with Java"}.
+     */
+    class SnakeCase implements DirectoryNameFormatter {
+
+        @Override
+        public String toDisplayName(String name) {
+            if (Objects.requireNonNull(name).isEmpty()) {
+                return name;
+            }
+            return Arrays.stream(name.split("_"))
+                    .map(word -> Character.toUpperCase(word.charAt(0)) + word.substring(1))
+                    .collect(Collectors.joining(" "));
+        }
+    }
+
+    /**
+     * {@code CamelCase} formatter that converts camelCase names into Title Case.
+     *
+     * <p>Example: {@code "myDirectoryName"} → {@code "My Directory Name"}.
+     *
+     * <p>Caveat: Minor words are capitalized as well, contrary to common Title Case standards.
+     * {@code "anIntroductionToProgrammingWithJava"} → {@code "An Introduction To Programming With Java"} instead of {@code "An Introduction to Programming with Java"}.
+     */
+    class CamelCase implements DirectoryNameFormatter {
+
+        @Override
+        public String toDisplayName(String name) {
+            if (Objects.requireNonNull(name).isEmpty()) {
+                return name;
+            }
+            return capitalizeWords(name.replaceAll(
+                    "(?<=\\p{Lu})(?=\\p{Lu}\\p{Ll})"
+                    + "|"
+                    + "(?<=[^\\p{Lu}])(?=\\p{Lu})"
+                    + "|"
+                    + "(?<=\\d)(?=\\p{Ll})"
+                    + "|"
+                    + "(?<=\\p{L})(?=[^A-Za-z])",
+                    " "));
+        }
+
+        private String capitalizeWords(String text) {
+            return Arrays.stream(text.split("\\s+"))
+                    .map(word -> Character.toUpperCase(word.charAt(0)) + word.substring(1))
+                    .collect(Collectors.joining(" "));
+        }
+
+    }
+
+    /**
+     * {@code KebabCase} formatter that converts kebab-case names into Title Case.
+     *
+     * <p>Example: {@code "my-directory-name"} → {@code "My Directory Name"}.
+     *
+     * <p>Caveat: Minor words are capitalized as well, contrary to common Title Case standards.
+     * {@code "an-introduction-to-programming-with-java"} → {@code "An Introduction To Programming With Java"} instead of {@code "An Introduction to Programming with Java"}.
+     */
+    class KebabCase implements DirectoryNameFormatter {
+
+        @Override
+        public String toDisplayName(String name) {
+            if (Objects.requireNonNull(name).isEmpty()) {
+                return name;
+            }
+            return Arrays.stream(name.split("-"))
+                    .map(word -> Character.toUpperCase(word.charAt(0)) + word.substring(1))
+                    .collect(Collectors.joining(" "));
+        }
+    }
+}

--- a/engine/src/main/java/com/trivago/cluecumber/engine/rendering/pages/renderering/PathComparator.java
+++ b/engine/src/main/java/com/trivago/cluecumber/engine/rendering/pages/renderering/PathComparator.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.trivago.cluecumber.engine.rendering.pages.renderering;
+
+import java.nio.file.Path;
+import java.util.Comparator;
+
+/**
+ * A comparator for {@link Path} objects that compares paths based on the following rules:
+ * <ul>
+ *     <li>If one path is a prefix of the other, the shorter path is considered "less than" the longer path.</li>
+ *     <li>Otherwise, paths are compared alphabetically based on their string representations.</li>
+ * </ul>
+ *
+ * <p>This comparator is useful when paths need to be sorted in a way that respects both prefix relationships
+ * and lexicographical order.
+ * For example, this ensures that a parent directory appears before its subdirectories
+ * in a sorted list.</p>
+ *
+ * <p>Example usage:</p>
+ * <pre>
+ * List&lt;Path&gt; paths = List.of(
+ *     Path.of("/a/b"),
+ *     Path.of("/a"),
+ *     Path.of("/b")
+ * );
+ * paths.sort(new PathComparator());
+ * // Result: ["/a", "/a/b", "/b"]
+ * </pre>
+ */
+public class PathComparator implements Comparator<Path> {
+
+    @Override
+    public int compare(Path path1, Path path2) {
+        String p1 = path1.toString();
+        String p2 = path2.toString();
+
+        // If one path is a prefix of the other, prioritize the shorter path
+        if (p1.startsWith(p2) || p2.startsWith(p1)) {
+            return Integer.compare(p1.length(), p2.length());
+        }
+
+        // Otherwise, sort alphabetically
+        return p1.compareTo(p2);
+    }
+}

--- a/engine/src/main/java/com/trivago/cluecumber/engine/rendering/pages/renderering/PathFormatter.java
+++ b/engine/src/main/java/com/trivago/cluecumber/engine/rendering/pages/renderering/PathFormatter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.trivago.cluecumber.engine.rendering.pages.renderering;
+
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * Formats a {@link Path} for display using a {@link DirectoryNameFormatter} for each element.
+ */
+public class PathFormatter {
+
+    private static final String ROOT_PATH = "/";
+
+    private final DirectoryNameFormatter directoryNameFormatter;
+
+    /**
+     * Constructor
+     *
+     * @param directoryNameFormatter The formatter to use for formatting each element of the path.
+     */
+    public PathFormatter(DirectoryNameFormatter directoryNameFormatter) {
+        this.directoryNameFormatter = directoryNameFormatter;
+    }
+
+    /**
+     * Formats the path using the configured {@link DirectoryNameFormatter}.
+     *
+     * <p>Example (using {@link com.trivago.cluecumber.engine.rendering.pages.renderering.DirectoryNameFormatter.KebabCase}):</p>
+     * {@code Path.of("/product-list/top-rated")} → {@code "Product List / Top Rated"}.
+     *
+     * @param path The path to be formatted
+     * @return The string to be displayed
+     */
+    public String formatPath(Path path) {
+        if (Objects.requireNonNull(path).getNameCount() == 0) {
+            return ROOT_PATH;
+        }
+        return StreamSupport.stream(path.spliterator(), false).map(Path::toString)
+                .map(directoryNameFormatter::toDisplayName)
+                .collect(Collectors.joining(" / "));
+    }
+}

--- a/engine/src/main/java/com/trivago/cluecumber/engine/rendering/pages/renderering/PathUtils.java
+++ b/engine/src/main/java/com/trivago/cluecumber/engine/rendering/pages/renderering/PathUtils.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.trivago.cluecumber.engine.rendering.pages.renderering;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public final class PathUtils {
+
+    private PathUtils() {
+    }
+
+    /**
+     * Extracts and normalizes the parent directory path from a URI or path string.
+     *
+     * <p>Returns {@code "/" } if there is no parent directory.
+     *
+     * @param uriString The URI or path string.
+     * @return The normalized parent directory as a {@link Path}, or {@code "/" } if there is no parent.
+     */
+    public static Path extractDirectoryPath(String uriString) {
+        try {
+            URI uri = new URI(uriString);
+            String rawPath = "classpath".equalsIgnoreCase(uri.getScheme())
+                    ? uri.getSchemeSpecificPart()
+                    : uri.getPath();
+
+            if (rawPath == null) {
+                // Handle cases where the path is null (e.g., malformed file URIs)
+                rawPath = uri.getSchemeSpecificPart();
+            }
+
+            Path normalizedPath = Paths.get(rawPath).normalize();
+            Path parent = normalizedPath.getParent();
+            return parent == null ? Path.of("/") : parent;
+        } catch (URISyntaxException | IllegalArgumentException e) {
+            // Fallback for invalid URIs or plain paths
+            Path normalizedPath = Paths.get(uriString).normalize();
+            Path parent = normalizedPath.getParent();
+            return parent == null ? Path.of("/") : parent;
+        }
+    }
+}

--- a/engine/src/main/resources/template/css/cluecumber.css
+++ b/engine/src/main/resources/template/css/cluecumber.css
@@ -80,13 +80,31 @@ a {
     text-align: center;
 }
 
-#tree-view li {
-    list-style-type: none;
-    text-align: left;
-}
+#tree-view {
+    h4 {
+        text-align: left;
+        background-color: #ddd;
+        padding: 0 0 0 0.5rem;
+        line-height: 2.5rem;
+        border-radius: calc(.25rem - 1px) calc(.25rem - 1px) 0 0;
+    }
 
-#tree-view ul li {
-    margin-bottom: .4rem;
+    h4:not(:first-child) {
+        margin-top: 2rem;
+    }
+
+    li {
+        list-style-type: none;
+        text-align: left;
+    }
+
+    ul {
+        padding-inline-start: 0;
+
+        li {
+            margin-bottom: .4rem;
+        }
+    }
 }
 
 .embedding-content {

--- a/engine/src/main/resources/template/tree-view.ftl
+++ b/engine/src/main/resources/template/tree-view.ftl
@@ -30,31 +30,40 @@ preheadlineLink="">
 
     <div class="row" id="tree-view">
         <@page.card width="12" title="${numberOfFeatures} ${common.pluralizeFn('Feature', numberOfFeatures)} with ${numberOfScenarios} ${common.pluralizeFn('Scenario', numberOfScenarios)}" subtitle="" classes="">
-            <ul>
-                <#list elements as feature, scenarios>
-                    <#assign tooltipText = "">
-                    <#if feature.description?has_content>
-                        <#assign tooltipText = "${feature.description} | ">
-                    </#if>
-                    <#assign tooltipText = "${tooltipText}${feature.uri}">
-                    <li>
-                        <span data-toggle="tooltip" title="${tooltipText}">
-                            <a href="pages/feature-scenarios/feature_${feature.index?c}.html"><strong>${feature.name?html}</strong></a>
-                        </span>
-                    </li>
-                    <ol type="1">
-                        <#list scenarios as scenario>
-                            <#if ((!scenario.isMultiRunParent() && !scenario.isMultiRunChild()) || scenario.isMultiRunParent()) >
-                                <li style="list-style-type: decimal;"><a
-                                            href="pages/scenario-detail/scenario_${scenario.scenarioIndex?c}.html"
-                                            style="word-break: break-all">${scenario.name?html}</a>
-                                </li>
-                            </#if>
-                        </#list>
-                    </ol>
-                    <hr>
-                </#list>
-            </ul>
+            <#list featuresByPath as path, features>
+                <#if featuresByPath?size &gt; 1 && path != "/">
+                    <h4>${pathFormatter.formatPath(path)}</h4>
+                </#if>
+                <ul>
+                    <#list features as featureWithScenarios>
+                        <#assign feature = featureWithScenarios.feature>
+                        <#assign scenarios = featureWithScenarios.scenarios>
+                        <#assign tooltipText = "">
+                        <#if feature.description?has_content>
+                            <#assign tooltipText = "${feature.description} | ">
+                        </#if>
+                        <#assign tooltipText = "${tooltipText}${feature.uri}">
+                        <li>
+                            <span data-toggle="tooltip" title="${tooltipText}">
+                                <a href="pages/feature-scenarios/feature_${feature.index?c}.html"><strong>${feature.name?html}</strong></a>
+                            </span>
+                        </li>
+                        <ol type="1">
+                            <#list scenarios as scenario>
+                                <#if ((!scenario.isMultiRunParent() && !scenario.isMultiRunChild()) || scenario.isMultiRunParent()) >
+                                    <li style="list-style-type: decimal;"><a
+                                                href="pages/scenario-detail/scenario_${scenario.scenarioIndex?c}.html"
+                                                style="word-break: break-all">${scenario.name?html}</a>
+                                    </li>
+                                </#if>
+                            </#list>
+                        </ol>
+                        <#if featureWithScenarios?has_next>
+                            <hr>
+                        </#if>
+                    </#list>
+                </ul>
+            </#list>
         </@page.card>
     </div>
 </@page.page>

--- a/engine/src/test/java/com/trivago/cluecumber/engine/properties/PropertyManagerTest.java
+++ b/engine/src/test/java/com/trivago/cluecumber/engine/properties/PropertyManagerTest.java
@@ -6,6 +6,7 @@ import com.trivago.cluecumber.engine.exceptions.filesystem.MissingFileException;
 import com.trivago.cluecumber.engine.exceptions.properties.WrongOrMissingPropertyException;
 import com.trivago.cluecumber.engine.filesystem.FileIO;
 import com.trivago.cluecumber.engine.logging.CluecumberLogger;
+import com.trivago.cluecumber.engine.rendering.pages.renderering.DirectoryNameFormatter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -65,7 +66,7 @@ public class PropertyManagerTest {
         verify(logger, times(2)).info(anyString(),
                 eq(CluecumberLogger.CluecumberLogLevel.DEFAULT),
                 eq(CluecumberLogger.CluecumberLogLevel.COMPACT));
-        verify(logger, times(13)).info(anyString(),
+        verify(logger, times(16)).info(anyString(),
                 eq(CluecumberLogger.CluecumberLogLevel.DEFAULT));
     }
 
@@ -212,6 +213,50 @@ public class PropertyManagerTest {
     }
 
     @Test
+    public void usePathTreeViewDefaultValueTest() {
+        assertFalse(propertyManager.isGroupFeaturesByPath());
+    }
+
+    @Test
+    public void setGroupFeaturesByPathToTrueTest() {
+        propertyManager.setGroupFeaturesByPath(true);
+        assertTrue(propertyManager.isGroupFeaturesByPath());
+    }
+
+    @Test
+    public void setGroupFeaturesByPathToFalseTest() {
+        propertyManager.setGroupFeaturesByPath(true);
+        propertyManager.setGroupFeaturesByPath(false);
+        assertFalse(propertyManager.isGroupFeaturesByPath());
+    }
+
+    @Test
+    public void directoryNameFormatterDefaultValueTest() {
+        assertTrue(propertyManager.getDirectoryNameFormatter() instanceof DirectoryNameFormatter.Standard);
+    }
+
+    @Test
+    public void setValidDirectoryNameFormatterTest() throws WrongOrMissingPropertyException {
+        propertyManager.setDirectoryNameFormatter(
+                "com.trivago.cluecumber.engine.rendering.pages.renderering.DirectoryNameFormatter$CamelCase");
+        assertTrue(propertyManager.getDirectoryNameFormatter() instanceof DirectoryNameFormatter.CamelCase);
+    }
+
+    @Test
+    public void setInvalidDirectoryNameFormatterClassNameTest() {
+        assertThrows(WrongOrMissingPropertyException.class, () -> {
+            propertyManager.setDirectoryNameFormatter("com.example.InvalidFormatter");
+        });
+    }
+
+    @Test
+    public void setNonImplementingClassDirectoryNameFormatterTest() {
+        assertThrows(WrongOrMissingPropertyException.class, () -> {
+            propertyManager.setDirectoryNameFormatter("java.lang.String");
+        });
+    }
+
+    @Test
     public void logFullPropertiesTest() throws MissingFileException {
         Map<String, String> customParameters = new HashMap<>();
         customParameters.put("key1", "value1");
@@ -225,7 +270,7 @@ public class PropertyManagerTest {
         verify(logger, times(2)).info(anyString(),
                 eq(CluecumberLogger.CluecumberLogLevel.DEFAULT),
                 eq(CluecumberLogger.CluecumberLogLevel.COMPACT));
-        verify(logger, times(16)).info(anyString(),
+        verify(logger, times(19)).info(anyString(),
                 eq(CluecumberLogger.CluecumberLogLevel.DEFAULT));
     }
 }

--- a/engine/src/test/java/com/trivago/cluecumber/engine/rendering/pages/pojos/pagecollections/BasePathsTest.java
+++ b/engine/src/test/java/com/trivago/cluecumber/engine/rendering/pages/pojos/pagecollections/BasePathsTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2023 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.trivago.cluecumber.engine.rendering.pages.pojos.pagecollections;
+
+import com.trivago.cluecumber.engine.rendering.pages.renderering.BasePaths;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BasePathsTest {
+
+    @Test
+    void testBasePathsRelativePathsBecomeAbsolute() {
+        List<Path> basePaths = List.of(
+                Path.of("/features/"),
+                Path.of("features/foo") // Relative path
+        );
+        BasePaths basePathsObject = new BasePaths(basePaths);
+
+        assertTrue(basePathsObject.getBasePaths().contains(Path.of("/features")));
+        assertTrue(basePathsObject.getBasePaths().contains(Path.of("/features/foo")));
+    }
+
+    @Test
+    void testExactMatch() {
+        BasePaths basePaths = new BasePaths(List.of(
+                Path.of("/features")
+        ));
+        Path inputPath = Path.of("/features");
+
+        Path result = basePaths.stripBasePath(inputPath);
+
+        assertEquals("/", result.toString());
+    }
+
+    @Test
+    void testRelativeMatch() {
+        BasePaths basePaths = new BasePaths(List.of(
+                Path.of("/features")
+        ));
+        Path inputPath = Path.of("features/foo");
+
+        Path result = basePaths.stripBasePath(inputPath);
+
+        assertEquals("/foo", result.toString());
+    }
+
+    @Test
+    void testLongestMatch() {
+        BasePaths basePaths = new BasePaths(List.of(
+                Path.of("/features"),
+                Path.of("/features/foo")
+        ));
+        Path inputPath = Path.of("/features/foo/blah");
+
+        Path result = basePaths.stripBasePath(inputPath);
+
+        assertNotNull(result);
+        assertEquals("/blah", result.toString());
+    }
+
+    @Test
+    void testNoMatch() {
+        BasePaths basePaths = new BasePaths(List.of(
+                Path.of("/unrelated/path")
+        ));
+        Path inputPath = Path.of("/features/foo/blah");
+
+        Path result = basePaths.stripBasePath(inputPath);
+
+        assertNotNull(result);
+        assertEquals("/features/foo/blah", result.toString());
+    }
+
+    @Test
+    void testRelativeInputPathWithAbsoluteBasePaths() {
+        BasePaths basePaths = new BasePaths(List.of(
+                Path.of("/features/"),
+                Path.of("/features/foo/")
+        ));
+        Path inputPath = Path.of("features/foo/blah"); // Relative input
+
+        Path result = basePaths.stripBasePath(inputPath);
+
+        assertNotNull(result);
+        assertEquals("/blah", result.toString());
+    }
+
+    @Test
+    void testNullInput() {
+        BasePaths basePaths = new BasePaths(List.of(
+                Path.of("/features")
+        ));
+
+        assertThrows(NullPointerException.class, () -> basePaths.stripBasePath(null));
+    }
+
+    @Test
+    void testEmptyBasePaths() {
+        BasePaths basePaths = new BasePaths(List.of());
+        Path inputPath = Path.of("/features/foo/blah");
+
+        Path result = basePaths.stripBasePath(inputPath);
+
+        assertNotNull(result);
+        assertEquals("/features/foo/blah", result.toString());
+    }
+}

--- a/engine/src/test/java/com/trivago/cluecumber/engine/rendering/pages/pojos/pagecollections/PojoTest.java
+++ b/engine/src/test/java/com/trivago/cluecumber/engine/rendering/pages/pojos/pagecollections/PojoTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 public class PojoTest {
-    private static final int EXPECTED_CLASS_COUNT = 12;
+    private static final int EXPECTED_CLASS_COUNT = 13;
     private static final String POJO_PACKAGE = "com.trivago.cluecumber.engine.rendering.pages.pojos.pagecollections";
 
     @BeforeAll

--- a/engine/src/test/java/com/trivago/cluecumber/engine/rendering/pages/renderering/DirectoryNameFormatterTest.java
+++ b/engine/src/test/java/com/trivago/cluecumber/engine/rendering/pages/renderering/DirectoryNameFormatterTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2023 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.trivago.cluecumber.engine.rendering.pages.renderering;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DirectoryNameFormatterTest {
+
+    @Nested
+    class StandardFormatterTests {
+
+        @Test
+        void shouldReturnNameAsIs() {
+            DirectoryNameFormatter formatter = new DirectoryNameFormatter.Standard();
+            assertEquals("Already Formatted", formatter.toDisplayName("Already Formatted"));
+        }
+
+        @Test
+        void shouldHandleEmptyInput() {
+            DirectoryNameFormatter formatter = new DirectoryNameFormatter.Standard();
+            assertEquals("", formatter.toDisplayName(""));
+        }
+
+        @Test
+        void shouldHandleNullInput() {
+            DirectoryNameFormatter formatter = new DirectoryNameFormatter.Standard();
+            assertThrows(NullPointerException.class, () -> formatter.toDisplayName(null));
+        }
+    }
+
+    @Nested
+    class SnakeCaseFormatterTests {
+
+        @Test
+        void shouldConvertSnakeCaseToTitleCase() {
+            DirectoryNameFormatter formatter = new DirectoryNameFormatter.SnakeCase();
+            assertEquals("This Is A Directory", formatter.toDisplayName("this_is_a_directory"));
+        }
+
+        @Test
+        void shouldHandleEmptyInput() {
+            DirectoryNameFormatter formatter = new DirectoryNameFormatter.SnakeCase();
+            assertEquals("", formatter.toDisplayName(""));
+        }
+
+        @Test
+        void shouldHandleSingleWord() {
+            DirectoryNameFormatter formatter = new DirectoryNameFormatter.SnakeCase();
+            assertEquals("Directory", formatter.toDisplayName("directory"));
+        }
+
+        @Test
+        void shouldHandleMixedCaseInput() {
+            DirectoryNameFormatter formatter = new DirectoryNameFormatter.SnakeCase();
+            assertEquals("Directory Loader", formatter.toDisplayName("directory_Loader"));
+        }
+
+        @Test
+        void shouldCapitalizeMinorWordsInSnakeCase() {
+            DirectoryNameFormatter formatter = new DirectoryNameFormatter.SnakeCase();
+            assertEquals("An Introduction To Programming With Java",
+                    formatter.toDisplayName("an_introduction_to_programming_with_java"));
+        }
+    }
+
+    @Nested
+    class CamelCaseFormatterTests {
+
+        @Test
+        void shouldConvertCamelCaseToTitleCase() {
+            DirectoryNameFormatter formatter = new DirectoryNameFormatter.CamelCase();
+            assertEquals("This Is A Directory", formatter.toDisplayName("thisIsADirectory"));
+        }
+
+        @Test
+        void shouldHandleSingleWord() {
+            DirectoryNameFormatter formatter = new DirectoryNameFormatter.CamelCase();
+            assertEquals("Directory", formatter.toDisplayName("directory"));
+        }
+
+        @Test
+        void shouldHandleMixedCaseInput() {
+            DirectoryNameFormatter formatter = new DirectoryNameFormatter.CamelCase();
+            assertEquals("Loader PDF", formatter.toDisplayName("loaderPDF"));
+        }
+
+        @Test
+        void shouldCapitalizeMinorWordsInCamelCase() {
+            DirectoryNameFormatter formatter = new DirectoryNameFormatter.CamelCase();
+            assertEquals("An Introduction To Programming With Java",
+                    formatter.toDisplayName("anIntroductionToProgrammingWithJava"));
+        }
+
+        @Test
+        void shouldHandleUpperCaseAcronymInCamelCase() {
+            DirectoryNameFormatter formatter = new DirectoryNameFormatter.CamelCase();
+            assertEquals("XML Parser", formatter.toDisplayName("XMLParser"));
+        }
+
+        @Test
+        void shouldHandleEmptyInput() {
+            DirectoryNameFormatter formatter = new DirectoryNameFormatter.CamelCase();
+            assertEquals("", formatter.toDisplayName(""));
+        }
+
+        @Test
+        void shouldHandleNumbersInCamelCase() {
+            DirectoryNameFormatter formatter = new DirectoryNameFormatter.CamelCase();
+
+            assertEquals("99 Bottles", formatter.toDisplayName("99bottles"));
+            assertEquals("Bottles 99", formatter.toDisplayName("bottles99"));
+            assertEquals("99 Bottles Of Beer", formatter.toDisplayName("99bottlesOfBeer"));
+        }
+    }
+
+    @Nested
+    class KebabCaseFormatterTests {
+
+        @Test
+        void shouldConvertKebabCaseToTitleCase() {
+            DirectoryNameFormatter formatter = new DirectoryNameFormatter.KebabCase();
+            assertEquals("This Is A Directory", formatter.toDisplayName("this-is-a-directory"));
+        }
+
+        @Test
+        void shouldHandleSingleWord() {
+            DirectoryNameFormatter formatter = new DirectoryNameFormatter.KebabCase();
+            assertEquals("Directory", formatter.toDisplayName("directory"));
+        }
+
+        @Test
+        void shouldHandleMixedCaseInput() {
+            DirectoryNameFormatter formatter = new DirectoryNameFormatter.KebabCase();
+            assertEquals("Loader Pdf", formatter.toDisplayName("loader-Pdf"));
+        }
+
+        @Test
+        void shouldCapitalizeMinorWordsInKebabCase() {
+            DirectoryNameFormatter formatter = new DirectoryNameFormatter.KebabCase();
+            assertEquals("An Introduction To Programming With Java",
+                    formatter.toDisplayName("an-introduction-to-programming-with-java"));
+        }
+
+        @Test
+        void shouldHandleEmptyInput() {
+            DirectoryNameFormatter formatter = new DirectoryNameFormatter.KebabCase();
+            assertEquals("", formatter.toDisplayName(""));
+        }
+    }
+}

--- a/engine/src/test/java/com/trivago/cluecumber/engine/rendering/pages/renderering/PathComparatorTest.java
+++ b/engine/src/test/java/com/trivago/cluecumber/engine/rendering/pages/renderering/PathComparatorTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.trivago.cluecumber.engine.rendering.pages.renderering;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PathComparatorTest {
+
+    private final PathComparator classUnderTest = new PathComparator();
+
+    @Test
+    void testSortPathsWithNestedSubsets() {
+        List<Path> paths = List.of(
+                Path.of("/features/shoppingcart"),
+                Path.of("/features/checkout/payment"),
+                Path.of("/features/checkout"),
+                Path.of("/features/"),
+                Path.of("/features/checkout/shipping")
+        );
+
+        paths = paths.stream()
+                .sorted(classUnderTest)
+                .collect(Collectors.toList());
+
+        List<Path> expectedOrder = List.of(
+                Path.of("/features/"),
+                Path.of("/features/checkout"),
+                Path.of("/features/checkout/payment"),
+                Path.of("/features/checkout/shipping"),
+                Path.of("/features/shoppingcart")
+        );
+
+        assertEquals(expectedOrder, paths);
+    }
+}

--- a/engine/src/test/java/com/trivago/cluecumber/engine/rendering/pages/renderering/PathUtilsTest.java
+++ b/engine/src/test/java/com/trivago/cluecumber/engine/rendering/pages/renderering/PathUtilsTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.trivago.cluecumber.engine.rendering.pages.renderering;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PathUtilsTest {
+
+    @ParameterizedTest(name = "Test case {index}: input=\"{0}\"")
+    @CsvSource({
+            "/resources/features/Login.feature, /resources/features",
+            "classpath:Calendar.feature,/",
+            "classpath:org/ShoppingCart.feature, org",
+            "feature/Karate.feature, feature",
+            "feature/../KarateEmbedded.feature,/",
+            "features/feature1.feature, features",
+            "features/../feature2.feature,/",
+            "file:API/src/test/resources/features/orion_user.feature, API/src/test/resources/features",
+            "file:API/src/test/resources/features/foo/../orion_user.feature, API/src/test/resources/features",
+            "file:target/parallel/features/MyTest10_scenario007_run001_IT.feature, target/parallel/features",
+            "http://example.com/features/test.feature, /features"
+    })
+    void testExtractDirectoryPath(String input, Path expected) {
+        Path actual = PathUtils.extractDirectoryPath(input);
+        assertEquals(expected, actual,
+                "Expected directory path for input \"" + input + "\" does not match.");
+    }
+}

--- a/engine/src/test/java/com/trivago/cluecumber/engine/rendering/pages/renderering/TreeViewPageRendererTest.java
+++ b/engine/src/test/java/com/trivago/cluecumber/engine/rendering/pages/renderering/TreeViewPageRendererTest.java
@@ -1,0 +1,115 @@
+package com.trivago.cluecumber.engine.rendering.pages.renderering;
+
+import com.trivago.cluecumber.engine.exceptions.CluecumberException;
+import com.trivago.cluecumber.engine.json.pojo.Report;
+import com.trivago.cluecumber.engine.properties.PropertyManager;
+import com.trivago.cluecumber.engine.rendering.pages.pojos.Feature;
+import com.trivago.cluecumber.engine.rendering.pages.pojos.pagecollections.AllFeaturesPageCollection;
+import com.trivago.cluecumber.engine.rendering.pages.pojos.pagecollections.AllScenariosPageCollection;
+import com.trivago.cluecumber.engine.rendering.pages.pojos.pagecollections.TreeViewPageCollection;
+import freemarker.template.Template;
+import freemarker.template.TemplateException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TreeViewPageRendererTest {
+
+    private TreeViewPageRenderer treeViewPageRenderer;
+    private PropertyManager propertyManager;
+
+    @BeforeEach
+    void setup() {
+        propertyManager = mock(PropertyManager.class);
+        treeViewPageRenderer = new TreeViewPageRenderer(propertyManager);
+    }
+
+    @Test
+    void testContentRenderingWithoutPathTreeView() throws CluecumberException, TemplateException, IOException {
+        Template template = mock(Template.class);
+        AllFeaturesPageCollection allFeaturesPageCollection = new AllFeaturesPageCollection(
+                List.of(aReportWithUri("/features/foo/feature1.feature")), "All Features");
+        AllScenariosPageCollection allScenariosPageCollection = new AllScenariosPageCollection("");
+
+        givenNoPathTreeView();
+
+        ArgumentCaptor<TreeViewPageCollection> pageCollectionCaptor = ArgumentCaptor.forClass(TreeViewPageCollection.class);
+
+        treeViewPageRenderer.getRenderedContent(
+                allFeaturesPageCollection,
+                allScenariosPageCollection,
+                template
+        );
+
+        verify(template, times(1)).process(pageCollectionCaptor.capture(), any());
+
+        TreeViewPageCollection capturedPageCollection = pageCollectionCaptor.getValue();
+        assertNotNull(capturedPageCollection);
+        assertEquals("All Features", capturedPageCollection.getPageTitle());
+        final Path expectedPath = Path.of("/");
+        assertEquals(capturedPageCollection.getPaths(), Set.of(expectedPath));
+        List<Feature> featuresAtPath = capturedPageCollection.getFeaturesByPath().get(expectedPath)
+                .stream().map(TreeViewPageCollection.FeatureAndScenarios::getFeature).collect(Collectors.toList());
+        assertTrue(featuresAtPath.containsAll(allFeaturesPageCollection.getFeatures()));
+    }
+
+    @Test
+    void testContentRenderingWithPathTreeView() throws CluecumberException, TemplateException, IOException {
+        Template template = mock(Template.class);
+        AllFeaturesPageCollection allFeaturesPageCollection = new AllFeaturesPageCollection(
+                List.of(aReportWithUri("/features/customers/registration/form_validation/email_address.feature")), "All Features");
+        AllScenariosPageCollection allScenariosPageCollection = new AllScenariosPageCollection("");
+
+        when(propertyManager.isGroupFeaturesByPath()).thenReturn(true);
+        when(propertyManager.getRemovableBasePaths()).thenReturn(BasePaths.fromStrings(List.of("/features")));
+        when(propertyManager.getDirectoryNameFormatter()).thenReturn(new DirectoryNameFormatter.SnakeCase());
+
+        ArgumentCaptor<TreeViewPageCollection> pageCollectionCaptor = ArgumentCaptor.forClass(TreeViewPageCollection.class);
+
+        treeViewPageRenderer.getRenderedContent(
+                allFeaturesPageCollection,
+                allScenariosPageCollection,
+                template
+        );
+
+        verify(template, times(1)).process(pageCollectionCaptor.capture(), any());
+
+        TreeViewPageCollection capturedPageCollection = pageCollectionCaptor.getValue();
+        assertNotNull(capturedPageCollection);
+        assertEquals("All Features", capturedPageCollection.getPageTitle());
+
+        final Path expectedPath = Path.of("/customers/registration/form_validation");
+        assertEquals(capturedPageCollection.getPaths(), Set.of(expectedPath));
+        List<Feature> featuresAtPath = capturedPageCollection.getFeaturesByPath().get(expectedPath)
+                .stream().map(TreeViewPageCollection.FeatureAndScenarios::getFeature).collect(Collectors.toList());
+        assertTrue(featuresAtPath.containsAll(allFeaturesPageCollection.getFeatures()));
+    }
+
+    private void givenNoPathTreeView() {
+        when(propertyManager.isGroupFeaturesByPath()).thenReturn(false);
+    }
+
+    private static Report aReportWithUri(String uri) {
+        Report report = new Report();
+        report.setName("Feature 1");
+        report.setDescription("Description");
+        report.setFeatureIndex(1);
+        report.setUri(uri);
+        return report;
+    }
+}

--- a/examples/core-example/pom.xml
+++ b/examples/core-example/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>blog.softwaretester</groupId>
     <artifactId>core-example</artifactId>
-    <version>3.10.0</version>
+    <version>3.11.0</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/examples/maven-example/pom.xml
+++ b/examples/maven-example/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>blog.softwaretester</groupId>
     <artifactId>maven-example</artifactId>
-    <version>3.10.0</version>
+    <version>3.11.0</version>
     <packaging>pom</packaging>
 
     <properties>
@@ -94,6 +94,16 @@
                     <!--<logLevel>compact</logLevel>-->
                     <!--<logLevel>minimal</logLevel>-->
                     <!--<logLevel>off</logLevel>-->
+
+                    <!-- optional grouping of features by their path in the tree view with options to prettify the paths -->
+                    <groupFeaturesByPath>false</groupFeaturesByPath>
+                    <removableBasePaths>
+                        <removableBasePath>feature</removableBasePath>
+                        <removableBasePath>features</removableBasePath>
+                    </removableBasePaths>
+                    <directoryNameFormatter>
+                        com.trivago.cluecumber.engine.rendering.pages.renderering.DirectoryNameFormatter$KebabCase
+                    </directoryNameFormatter>
 
                     <!-- Optionally skip the whole report generation -->
                     <!-- <skip>true</skip> -->

--- a/maven/src/main/java/com/trivago/cluecumber/maven/CluecumberMaven.java
+++ b/maven/src/main/java/com/trivago/cluecumber/maven/CluecumberMaven.java
@@ -25,6 +25,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
 import java.util.LinkedHashMap;
+import java.util.Set;
 
 /**
  * The main plugin class.
@@ -94,6 +95,24 @@ public final class CluecumberMaven extends AbstractMojo {
      */
     @Parameter(property = "reporting.customFavicon")
     private String customFavicon = "";
+
+    /**
+     * The base paths to be removed from feature file URIs before grouping.
+     */
+    @Parameter(property = "reporting.removableBasePaths")
+    private Set<String> removableBasePaths;
+
+    /**
+     * The fully qualified class name of the directory name formatter implementation (default: com.trivago.cluecumber.engine.rendering.pages.renderering.DirectoryNameFormatter$Standard).
+     */
+    @Parameter(property = "reporting.directoryNameFormatter", defaultValue = "com.trivago.cluecumber.engine.rendering.pages.renderering.DirectoryNameFormatter$Standard")
+    private String directoryNameFormatter;
+
+    /**
+     * Whether to use a path-based tree view for grouping features (default: false).
+     */
+    @Parameter(property = "reporting.groupFeaturesByPath", defaultValue = "false")
+    private boolean groupFeaturesByPath;
 
     /**
      * Custom flag that determines if step output sections of scenario detail pages should be expanded (default: false).
@@ -203,6 +222,9 @@ public final class CluecumberMaven extends AbstractMojo {
                     .setCustomParametersFile(customParametersFile)
                     .setCustomStatusColorFailed(customStatusColorFailed)
                     .setCustomStatusColorPassed(customStatusColorPassed)
+                    .setRemovableBasePaths(removableBasePaths)
+                    .setDirectoryNameFormatter(directoryNameFormatter)
+                    .setGroupFeaturesByPath(groupFeaturesByPath)
                     .setExpandSubSections(expandSubSections)
                     .setExpandOutputs(expandOutputs)
                     .setExpandAttachments(expandAttachments)

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     </modules>
 
     <properties>
-        <revision>3.10.0</revision>
+        <revision>3.11.0</revision>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.release>11</maven.compiler.release>


### PR DESCRIPTION
### Background
See #366

### Changes

Introduced an optional feature to group feature files by their directory paths in the tree view, providing a better overview of features for teams that organize them by functionality in nested directories.

The default behavior remains unchanged, with features listed without grouping for backward compatibility.

Added new configuration options:
- `groupFeaturesByPath`: Enables or disables path-based grouping (default: false).
- `removableBasePaths`: Specifies base paths to strip from feature file URIs before grouping.
- `directoryNameFormatter`: Customizes how directory names are displayed in the grouped tree view.

### Development

I hope that it's ok that I suggest one approach on how to implement the feature request linked above. I understood by you assigning it to the next release version that you would be open to support this feature.

Regarding the implementation:
- I tried to follow your naming conventions and code style as best as possible - but please feel free to request changes. In particular I did not find any information regarding the style guide / formatter / linter and therefore just followed some IntelliJ built-ins.
-  I was not sure about the location of some of the newly introduced classes.
- I used Java 11 as the baseline and avoided newer APIs. There is probably some slight code style optimization possible if we baseline on 17.
- The name of the configuration properties are up for discussion - please feel more than welcome to suggest better names.
- I followed the versioning strategy and increased the version as documented in the contribution guidelines. 
- The styling is my initial suggestion and very much open to changes

### Screenshot

The existing test JSONs are not the best at showcasing the intent of the feature. But nevertheless, if you switch `groupFeaturesByPath` to `true` you can see it in action:

![image](https://github.com/user-attachments/assets/2f382259-a499-4e74-9153-3165ae5943cc)


