### PR TITLE
fix quadratic performance of tag/step/exception scenario filtering

### DIFF
--- a/engine/src/main/java/com/trivago/cluecumber/engine/rendering/pages/pojos/pagecollections/AllScenariosPageCollection.java
+++ b/engine/src/main/java/com/trivago/cluecumber/engine/rendering/pages/pojos/pagecollections/AllScenariosPageCollection.java
@@ -46,7 +46,11 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -60,6 +64,12 @@ public class AllScenariosPageCollection extends PageCollection implements Visita
     private Feature featureFilter;
     private Step stepFilter;
     private String exceptionFilter;
+
+    // Lazily computed and cached lookup indices, so that rendering the "scenarios by X" pages for every
+    // unique tag/step/exception does not require a full re-scan of all reports and elements for each of them.
+    private Map<Tag, Map<Integer, List<Element>>> elementsByTagAndReportIndex;
+    private Map<Step, Map<Integer, List<Element>>> elementsByStepAndReportIndex;
+    private Map<String, Map<Integer, List<Element>>> elementsByExceptionAndReportIndex;
 
     /**
      * Constructor.
@@ -429,6 +439,84 @@ public class AllScenariosPageCollection extends PageCollection implements Visita
     }
 
     /**
+     * Group all elements by tag and the index of their originating report.
+     * <p>
+     * This is computed once and cached instead of being recomputed for every unique tag, since the
+     * "scenarios by tag" page is rendered once per unique tag and a full re-scan of all reports and
+     * elements for each of them can be very expensive for reports with many scenarios and tags.
+     *
+     * @return A map of tag to a map of report index to the matching elements of that report.
+     */
+    public Map<Tag, Map<Integer, List<Element>>> getElementsByTagAndReportIndex() {
+        if (elementsByTagAndReportIndex == null) {
+            elementsByTagAndReportIndex = new HashMap<>();
+            for (int reportIndex = 0; reportIndex < reports.size(); reportIndex++) {
+                for (Element element : reports.get(reportIndex).getElements()) {
+                    for (Tag tag : new HashSet<>(element.getTags())) {
+                        elementsByTagAndReportIndex
+                                .computeIfAbsent(tag, key -> new HashMap<>())
+                                .computeIfAbsent(reportIndex, key -> new ArrayList<>())
+                                .add(element);
+                    }
+                }
+            }
+        }
+        return elementsByTagAndReportIndex;
+    }
+
+    /**
+     * Group all elements (including background steps) by step and the index of their originating report.
+     * <p>
+     * This is computed once and cached instead of being recomputed for every unique step, since the
+     * "scenarios by step" page is rendered once per unique step and a full re-scan of all reports and
+     * elements for each of them can be very expensive for reports with many scenarios and steps.
+     *
+     * @return A map of step to a map of report index to the matching elements of that report.
+     */
+    public Map<Step, Map<Integer, List<Element>>> getElementsByStepAndReportIndex() {
+        if (elementsByStepAndReportIndex == null) {
+            elementsByStepAndReportIndex = new HashMap<>();
+            for (int reportIndex = 0; reportIndex < reports.size(); reportIndex++) {
+                for (Element element : reports.get(reportIndex).getElements()) {
+                    final Set<Step> distinctSteps = new HashSet<>(element.getSteps());
+                    distinctSteps.addAll(element.getBackgroundSteps());
+                    for (Step step : distinctSteps) {
+                        elementsByStepAndReportIndex
+                                .computeIfAbsent(step, key -> new HashMap<>())
+                                .computeIfAbsent(reportIndex, key -> new ArrayList<>())
+                                .add(element);
+                    }
+                }
+            }
+        }
+        return elementsByStepAndReportIndex;
+    }
+
+    /**
+     * Group all elements by their first exception class and the index of their originating report.
+     * <p>
+     * This is computed once and cached instead of being recomputed for every unique exception, since the
+     * "scenarios by exception" page is rendered once per unique exception and a full re-scan of all reports
+     * and elements for each of them can be very expensive for reports with many scenarios and exceptions.
+     *
+     * @return A map of exception class to a map of report index to the matching elements of that report.
+     */
+    public Map<String, Map<Integer, List<Element>>> getElementsByExceptionAndReportIndex() {
+        if (elementsByExceptionAndReportIndex == null) {
+            elementsByExceptionAndReportIndex = new HashMap<>();
+            for (int reportIndex = 0; reportIndex < reports.size(); reportIndex++) {
+                for (Element element : reports.get(reportIndex).getElements()) {
+                    elementsByExceptionAndReportIndex
+                            .computeIfAbsent(element.getFirstExceptionClass(), key -> new HashMap<>())
+                            .computeIfAbsent(reportIndex, key -> new ArrayList<>())
+                            .add(element);
+                }
+            }
+        }
+        return elementsByExceptionAndReportIndex;
+    }
+
+    /**
      * Function to clone the {@link AllScenariosPageCollection} including all included data.
      *
      * @return The clone of the {@link AllScenariosPageCollection}
@@ -440,12 +528,55 @@ public class AllScenariosPageCollection extends PageCollection implements Visita
         clone.setStepFilter(null);
         clone.setTagFilter(null);
         clone.setExceptionFilter(null);
+        // A clone only ever holds a (filtered) subset of reports, so any lookup index cached on the
+        // source collection would be stale and must be recomputed if it were ever accessed on the clone.
+        clone.elementsByTagAndReportIndex = null;
+        clone.elementsByStepAndReportIndex = null;
+        clone.elementsByExceptionAndReportIndex = null;
         clone.clearReports();
         List<Report> clonedReports = new ArrayList<>();
         for (Report r : getReports()) {
             clonedReports.add((Report) r.clone());
         }
         clone.addReports(clonedReports);
+        return clone;
+    }
+
+    /**
+     * Clone this collection, but include only the reports that have at least one matching element
+     * (narrowed down to just those matching elements), as given by a report-index-to-elements map
+     * such as the ones returned by {@link #getElementsByTagAndReportIndex()}.
+     * <p>
+     * This is used instead of {@link #clone()} for the "scenarios by tag/step/exception" pages: since
+     * most reports typically do not match a given tag/step/exception, cloning and carrying around all
+     * of them (and repeatedly re-computing statistics like chart counts or start/end times over all of
+     * them) for every one of the potentially many unique tags/steps/exceptions is very wasteful.
+     *
+     * @param matchingElementsByReportIndex A map of original report index to its matching elements.
+     * @return The filtered clone, containing only reports that have at least one matching element.
+     */
+    public AllScenariosPageCollection cloneWithOnlyMatchingReports(
+            final Map<Integer, List<Element>> matchingElementsByReportIndex) throws CloneNotSupportedException {
+        final AllScenariosPageCollection clone = (AllScenariosPageCollection) super.clone();
+        clone.setFeatureFilter(null);
+        clone.setStepFilter(null);
+        clone.setTagFilter(null);
+        clone.setExceptionFilter(null);
+        clone.elementsByTagAndReportIndex = null;
+        clone.elementsByStepAndReportIndex = null;
+        clone.elementsByExceptionAndReportIndex = null;
+        clone.clearReports();
+        List<Report> filteredReports = new ArrayList<>();
+        for (int reportIndex = 0; reportIndex < reports.size(); reportIndex++) {
+            List<Element> matchingElements = matchingElementsByReportIndex.get(reportIndex);
+            if (matchingElements == null || matchingElements.isEmpty()) {
+                continue;
+            }
+            Report reportClone = (Report) reports.get(reportIndex).clone();
+            reportClone.setElements(new ArrayList<>(matchingElements));
+            filteredReports.add(reportClone);
+        }
+        clone.addReports(filteredReports);
         return clone;
     }
 

--- a/engine/src/main/java/com/trivago/cluecumber/engine/rendering/pages/renderering/AllScenariosPageRenderer.java
+++ b/engine/src/main/java/com/trivago/cluecumber/engine/rendering/pages/renderering/AllScenariosPageRenderer.java
@@ -31,7 +31,9 @@ import io.pebbletemplates.pebble.template.PebbleTemplate;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -116,16 +118,11 @@ public class AllScenariosPageRenderer extends PageWithChartRenderer {
             final PebbleTemplate template,
             final Tag tag) throws CluecumberException {
 
-        AllScenariosPageCollection allScenariosPageCollectionClone = getAllScenariosPageCollectionClone(allScenariosPageCollection);
+        Map<Integer, List<Element>> matchingElementsByReportIndex =
+                allScenariosPageCollection.getElementsByTagAndReportIndex().getOrDefault(tag, Collections.emptyMap());
+        AllScenariosPageCollection allScenariosPageCollectionClone =
+                getFilteredAllScenariosPageCollectionClone(allScenariosPageCollection, matchingElementsByReportIndex);
         allScenariosPageCollectionClone.setTagFilter(tag);
-
-        allScenariosPageCollectionClone.getReports().forEach(report -> {
-            List<Element> elements = report.getElements()
-                    .stream()
-                    .filter(element -> element.getTags().contains(tag))
-                    .collect(Collectors.toList());
-            report.setElements(elements);
-        });
 
         addChartJsonToReportDetails(allScenariosPageCollectionClone);
         return processedContent(template, allScenariosPageCollectionClone, propertyManager.getNavigationLinks());
@@ -145,16 +142,12 @@ public class AllScenariosPageRenderer extends PageWithChartRenderer {
             final PebbleTemplate template,
             final String exceptionClass) throws CluecumberException {
 
-        AllScenariosPageCollection allScenariosPageCollectionClone = getAllScenariosPageCollectionClone(allScenariosPageCollection);
+        Map<Integer, List<Element>> matchingElementsByReportIndex =
+                allScenariosPageCollection.getElementsByExceptionAndReportIndex()
+                        .getOrDefault(exceptionClass, Collections.emptyMap());
+        AllScenariosPageCollection allScenariosPageCollectionClone =
+                getFilteredAllScenariosPageCollectionClone(allScenariosPageCollection, matchingElementsByReportIndex);
         allScenariosPageCollectionClone.setExceptionFilter(exceptionClass);
-
-        allScenariosPageCollectionClone.getReports().forEach(report -> {
-            List<Element> elements = report.getElements()
-                    .stream()
-                    .filter(element -> element.getFirstExceptionClass().equals(exceptionClass))
-                    .collect(Collectors.toList());
-            report.setElements(elements);
-        });
 
         addChartJsonToReportDetails(allScenariosPageCollectionClone);
         return processedContent(template, allScenariosPageCollectionClone, propertyManager.getNavigationLinks());
@@ -175,15 +168,11 @@ public class AllScenariosPageRenderer extends PageWithChartRenderer {
             final PebbleTemplate template,
             final Step step) throws CluecumberException {
 
-        AllScenariosPageCollection allScenariosPageCollectionClone = getAllScenariosPageCollectionClone(allScenariosPageCollection);
+        Map<Integer, List<Element>> matchingElementsByReportIndex =
+                allScenariosPageCollection.getElementsByStepAndReportIndex().getOrDefault(step, Collections.emptyMap());
+        AllScenariosPageCollection allScenariosPageCollectionClone =
+                getFilteredAllScenariosPageCollectionClone(allScenariosPageCollection, matchingElementsByReportIndex);
         allScenariosPageCollectionClone.setStepFilter(step);
-        for (Report report : allScenariosPageCollectionClone.getReports()) {
-            List<Element> elements = report.getElements()
-                    .stream()
-                    .filter(element -> element.getSteps().contains(step) || element.getBackgroundSteps().contains(step))
-                    .collect(Collectors.toList());
-            report.setElements(elements);
-        }
 
         addChartJsonToReportDetails(allScenariosPageCollectionClone);
         return processedContent(template, allScenariosPageCollectionClone, propertyManager.getNavigationLinks());
@@ -227,12 +216,36 @@ public class AllScenariosPageRenderer extends PageWithChartRenderer {
 
     private AllScenariosPageCollection getAllScenariosPageCollectionClone(
             final AllScenariosPageCollection allScenariosPageCollection) throws CluecumberException {
-        AllScenariosPageCollection clone;
         try {
-            clone = allScenariosPageCollection.clone();
+            return finalizeClone(allScenariosPageCollection.clone());
         } catch (CloneNotSupportedException e) {
             throw new CluecumberException("Clone of AllScenariosPageCollection not supported: " + e.getMessage());
         }
+    }
+
+    /**
+     * Get a clone of the given {@link AllScenariosPageCollection} that contains only the reports that have
+     * at least one element matching the given report-index-to-elements map, instead of a full clone of all
+     * reports. Rendering the "scenarios by tag/step/exception" pages for every one of the potentially many
+     * unique tags/steps/exceptions otherwise requires carrying around (and repeatedly computing statistics
+     * for) reports that will not be part of the rendered page anyway.
+     *
+     * @param allScenariosPageCollection    The source {@link AllScenariosPageCollection} instance.
+     * @param matchingElementsByReportIndex A map of original report index to its matching elements.
+     * @return The filtered clone.
+     * @throws CluecumberException Thrown on any error.
+     */
+    private AllScenariosPageCollection getFilteredAllScenariosPageCollectionClone(
+            final AllScenariosPageCollection allScenariosPageCollection,
+            final Map<Integer, List<Element>> matchingElementsByReportIndex) throws CluecumberException {
+        try {
+            return finalizeClone(allScenariosPageCollection.cloneWithOnlyMatchingReports(matchingElementsByReportIndex));
+        } catch (CloneNotSupportedException e) {
+            throw new CluecumberException("Clone of AllScenariosPageCollection not supported: " + e.getMessage());
+        }
+    }
+
+    private AllScenariosPageCollection finalizeClone(final AllScenariosPageCollection clone) {
         addCustomParametersToReportDetails(clone, propertyManager.getCustomParameters());
         clone.setGroupPreviousScenarioRuns(propertyManager.isGroupPreviousScenarioRuns());
         clone.setExpandPreviousScenarioRuns(propertyManager.isExpandPreviousScenarioRuns());


### PR DESCRIPTION
## What existing problem does this solve?

Report generation time scales far worse than linearly with the number of
scenarios. On a real-world report with 7619 scenarios, generation took
over 4 minutes; a report with 822 scenarios (9x fewer) took only ~7
seconds — a ~36x-input-ratio producing a ~34x-time-ratio would be
expected for linear behavior, but the actual slowdown is much worse.

Root cause: `TagVisitor`, `StepVisitor`, and `ExceptionVisitor` render one
"scenarios by X" page per unique tag/step/exception. For *each* of those
pages, `AllScenariosPageRenderer` was:

1. Cloning the entire `AllScenariosPageCollection` (all N reports), and
2. Linearly scanning every report's elements with `.contains()` to find
   matches, then
3. Re-computing chart/timing statistics over all N (mostly now-empty)
   reports again.

Since the number of unique tags (and, depending on the report, steps)
tends to grow roughly linearly with the number of scenarios, this makes
total generation cost effectively O(n²) for reports with many scenarios.

Confirmed via JFR profiling: the two hottest call stacks were the
per-tag/step `.contains()` filtering and the repeated
`AllScenariosPageCollection.clone()` calls.

## What changed

- `AllScenariosPageCollection`: added lazily-computed, cached indices
  (`getElementsByTagAndReportIndex()`, `getElementsByStepAndReportIndex()`,
  `getElementsByExceptionAndReportIndex()`) that group elements by
  tag/step/exception and originating report index in a single pass over
  all reports, plus a new `cloneWithOnlyMatchingReports(...)` that builds
  a filtered clone directly from only the matching reports instead of
  cloning all N reports and filtering afterwards.
- `AllScenariosPageRenderer`: `getRenderedContentByTagFilter`,
  `getRenderedContentByStepFilter`, and `getRenderedContentByExceptionFilter`
  now use these cached indices instead of re-scanning all reports/elements
  for every unique tag/step/exception.

No public API, template, or output format changes — this is purely an
internal performance optimization.

## Results

Engine execution time (JSON parsing + rendering), same machine/run:

| Scenarios | Before | After | Speedup |
|---:|---:|---:|---:|
| 492  | 3.1s   | 3.3s  | ~1x (fixed overhead dominates at this size) |
| 822  | 7.1s   | 7.6s  | ~1x (same reason) |
| 7619 | 242.2s | 36.1s | **~6.7x** |

## Testing

- Full engine test suite passes (pre-existing, unrelated failure in
  `FileSystemManagerTest#createInvalidDirectory` not caused by this
  change — `new File("").exists()` returns true in this environment,
  causing the expected `PathCreationException` not to be thrown).
- Verified generated output is unchanged: for three real-world reports
  (492 / 822 / 7619 scenarios), the set of generated files is identical
  before/after, and rendered HTML content is byte-for-byte identical
  after stripping the embedded "report generated on" timestamp.
- Manually diffed a step/tag page between the old and new code paths;
  the only difference found during development was incidental
  whitespace from template loop nesting (fixed by using the smaller,
  filtered report list directly), not content.

## Closing issues

#410 

---

Disclaimer: Created with Claude, reviewed by me.